### PR TITLE
Add Namespaces.UnusedUses rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ We follow the PSR-2 coding style with additional rules.
     ```
  - Php must contains ```declare(strict_types=1);``` with one blank line between declaration and php open tag.
  - Visibility MUST be declared on all constants  (PSR-12).
+ - No unused imports (`use` statements). 
 
 ### naming
 

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": "^7.2",
         "escapestudios/symfony2-coding-standard": "^3.4",
         "object-calisthenics/phpcs-calisthenics-rules": "^3.3",
-        "slevomat/coding-standard": "^4.6",
+        "slevomat/coding-standard": "^4.7",
         "squizlabs/php_codesniffer": "^3.3",
         "wp-coding-standards/wpcs": "^1.0"
     },

--- a/src/Geolid/ruleset.xml
+++ b/src/Geolid/ruleset.xml
@@ -64,4 +64,5 @@
     <rule ref="SlevomatCodingStandard.Classes.UnusedPrivateElements"/>
     <!--TODO : remove when phpcs-psr12 is in master -->
     <rule ref="SlevomatCodingStandard.Classes.ClassConstantVisibility"/>
+    <rule ref="SlevomatCodingStandard.Namespaces.UnusedUses"/>
 </ruleset>

--- a/src/Geolid/ruleset.xml
+++ b/src/Geolid/ruleset.xml
@@ -64,5 +64,9 @@
     <rule ref="SlevomatCodingStandard.Classes.UnusedPrivateElements"/>
     <!--TODO : remove when phpcs-psr12 is in master -->
     <rule ref="SlevomatCodingStandard.Classes.ClassConstantVisibility"/>
-    <rule ref="SlevomatCodingStandard.Namespaces.UnusedUses"/>
+    <rule ref="SlevomatCodingStandard.Namespaces.UnusedUses">
+        <properties>
+            <property name="searchAnnotations" value="true"/>
+        </properties>
+    </rule>
 </ruleset>


### PR DESCRIPTION
Detects unused (including invalid) `use` statements, especially useful for bulk renaming.
https://github.com/slevomat/coding-standard#slevomatcodingstandardnamespacesunuseduses-