### PR TITLE
Update vendors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor/
 composer.lock
 .php_cs.cache
+docker-compose.override.yml

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 vendor/
 composer.lock
-.php_cs.cache
+.php-cs-fixer.cache
 docker-compose.override.yml

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 use PhpCsFixer\Finder;
 
-$config = include __DIR__ . '/vendor/geolid/phpcs/src/Geolid/.php_cs.php';
+$config = include __DIR__ . '/vendor/geolid/phpcs/src/Geolid/.php-cs-fixer.php';
 
 return $config
     ->setFinder(Finder::create()

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,71 @@
+FIG=docker-compose
+HAS_DOCKER:=$(shell command -v $(FIG) 2> /dev/null)
+ifdef HAS_DOCKER
+	USERID=$(shell id -u)
+	GROUPID=$(shell id -g)
+	EXEC=$(FIG) exec -u $(USERID):$(GROUPID) app
+else
+	EXEC=
+endif
+SF=$(EXEC) symfony
+.DEFAULT_GOAL := help
+
+help:
+	@grep -E '(^[a-zA-Z_-]+:.*?##.*$$)|(^##)' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[32m%-30s\033[0m %s\n", $$1, $$2}' | sed -e 's/\[32m##/[33m/'
+.PHONY: help
+
+##
+## Project setup & day to day shortcuts
+##---------------------------------------------------------------------------
+
+up:
+	$(FIG) pull
+	$(FIG) build --pull
+	$(FIG) up -d
+.PHONY: up
+
+start: ## Start the project (Install in first place)
+start: docker-compose.override.yml up vendor
+.PHONY: start
+
+stop: ## Stop docker containers
+	$(FIG) down
+.PHONY: stop
+
+destroy: ## Destroy docker containers and volumes
+	$(FIG) down -v
+.PHONY: destroy
+
+sh: ## Run bash in the app container
+	$(EXEC) /bin/bash
+.PHONY: sh
+
+logs: ## Display logs. Use [log.nginx | log.app | log.db | log.maxmind | log.redis]
+log.%:
+	$(FIG) logs -f $(*)
+.PHONY: logs
+
+##
+## Tests
+##---------------------------------------------------------------------------
+
+tests: ## Run all our tests
+tests: phpunit security
+.PHONY: tests
+
+phpunit: ## Run phpunit test suite (You pass options to phpunit: make phpunit -- --filter PeriodTest)
+	$(EXEC) composer test
+.PHONY: phpunit
+
+security: ## Check security of your dependencies (https://security.sensiolabs.org/) => web service end working on January 2021 TODO: replace by the Open-Source CLI tool that does the same locally, or use the Symfony CLI tool
+	$(SF) check:security
+.PHONY: security
+
+# File rules
+docker-compose.override.yml: docker-compose.override.yml.dist
+	cp docker-compose.override.yml.dist docker-compose.override.yml
+.PHONY: docker-compose.override.yml
+
+vendor:
+	$(EXEC) composer install --prefer-dist --no-progress --no-suggest --no-interaction
+.PHONY: vendor

--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,8 @@
     "require": {
         "php": "^7.3|^8.0",
         "escapestudios/symfony2-coding-standard": "^3.10",
-        "friendsofphp/php-cs-fixer": "^2.16.1",
-        "object-calisthenics/phpcs-calisthenics-rules": "^3.7",
-        "slevomat/coding-standard": "^6.0.8",
+        "friendsofphp/php-cs-fixer": "^3.2.1",
+        "slevomat/coding-standard": "^7.0.16",
         "squizlabs/php_codesniffer": "^3.5.3"
     },
     "config": {
@@ -22,8 +21,8 @@
     },
     "scripts": {
         "test": [
-            "vendor/bin/phpcs --standard=src/Geolid/ruleset.xml tests/Example/",
-            "vendor/bin/php-cs-fixer fix tests/ --dry-run --config=src/Geolid/.php_cs.php --diff --using-cache=no"
+            "vendor/bin/phpcs --standard=src/Geolid/ruleset.xml tests/Example/ -v",
+            "vendor/bin/php-cs-fixer fix tests/ --dry-run --config=src/Geolid/.php-cs-fixer.php --diff --using-cache=no -v"
         ]
     }
 }

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,10 @@
+version: "3"
+
+services:
+  app:
+    environment:
+      - COMPOSER_CACHE_DIR=/home/app/.cache/composer
+      - COMPOSER_HOME=/home/app/.config/composer
+    volumes:
+      - ~/.cache/composer:/home/app/.cache/composer
+      - ~/.config/composer:/home/app/.config/composer

--- a/docker-compose.override.yml.dist
+++ b/docker-compose.override.yml.dist
@@ -1,0 +1,10 @@
+version: "3"
+
+services:
+  app:
+    environment:
+      - COMPOSER_CACHE_DIR=/home/app/.cache/composer
+      - COMPOSER_HOME=/home/app/.config/composer
+    volumes:
+      - ~/.cache/composer:/home/app/.cache/composer
+      - ~/.config/composer:/home/app/.config/composer

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: "3"
+
+services:
+  app:
+    image: geolid/php:7.4-dev
+    volumes:
+      - .:/srv

--- a/src/Geolid/.php-cs-fixer.php
+++ b/src/Geolid/.php-cs-fixer.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-return PhpCsFixer\Config::create()
+return (new PhpCsFixer\Config)
     ->setRules([
         '@PSR2' => true,
         'array_syntax' => [
@@ -43,7 +43,7 @@ return PhpCsFixer\Config::create()
         ],
         'short_scalar_cast' => true,
         'single_trait_insert_per_statement' => true,
-        'trailing_comma_in_multiline_array' => true,
+        'trailing_comma_in_multiline' => ['elements' => ['arrays']],
     ])
     ->setRiskyAllowed(true)
 ;

--- a/src/Geolid/ruleset.xml
+++ b/src/Geolid/ruleset.xml
@@ -17,12 +17,6 @@
     <rule ref="PSR12.Operators.OperatorSpacing" />
     <rule ref="PSR12.Keywords.ShortFormTypeKeywords" />
 
-    <rule ref="ObjectCalisthenics.Metrics.MaxNestingLevel">
-        <properties>
-            <property name="maxNestingLevel" value="3" />
-        </properties>
-    </rule>
-
     <rule ref="Symfony.NamingConventions.ValidClassName" />
     <rule ref="Symfony.NamingConventions.ValidClassName.InvalidAbstractName">
         <exclude-pattern>*TestCase.php</exclude-pattern>
@@ -35,8 +29,7 @@
         </properties>
     </rule>
 
-    <rule ref="SlevomatCodingStandard.Classes.UnusedPrivateElements"/>
     <!--TODO : remove when phpcs-psr12 is in master -->
     <rule ref="SlevomatCodingStandard.Classes.ClassConstantVisibility"/>
-    <rule ref="SlevomatCodingStandard.Functions.TrailingCommaInCall"/>
+    <rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInCall"/>
 </ruleset>


### PR DESCRIPTION
Cette PR est pour se mettre a jour sur notre projet de coding style, pas mal de changements pour mettre a jour, entrainant un BC break sur les projet qui utiliseront la nouvelle version (il faudra créer un tag version majeur pour cette PR)
- La nomenclature des fichiers à appeler dans son projet ont changé, conf https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/master/UPGRADE-v3.md#rename-of-files
- Le projet object-calisthenics/phpcs-calisthenics-rules est déprécié au profit d'une règle phpstan, conf https://github.com/object-calisthenics/phpcs-calisthenics-rules#object-calisthenics-rules-for-php_codesniffer
- La rule SlevomatCodingStandard.Classes.UnusedPrivateElements à été supprimé au profit également d'une rule phpstan, conf  https://github.com/slevomat/coding-standard/blob/696dcca217d0c9da2c40d02731526c1e25b65346/SlevomatCodingStandard/Sniffs/Classes/UnusedPrivateElementsSniff.php#L61

Du coup on perd 2 rules de quality code qu'il faudrai remettre manuellement dans chaque projets dans les configs phpstan.
J'ai l'impression qu'a la conception de ce package geolid/phpcs il a été décidé que phpcs pouvais être mutualiser entre tous les projet et phpstan était plus spécifique à chaque projet.
J'aimerai rediscuter de cette décision car je pense qu'il pourrait être utile de faire évoluer ce projet pour également intégrer des rule de phpstan, que l'ont intègrerai au final dans chaque projet simplement dans les includes phpstan:
```
includes:
    - vendor/geolid/phpcs/phpstan-rules/config/geolid.neon
```
Ou un truc du genre


